### PR TITLE
Redirect subscription page to Stripe portal

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -17,7 +17,6 @@
             <a href="{{ url_for('seller_dashboard') }}" class="btn">Dashboard</a>
             <a href="{{ url_for('new_product') }}" class="btn">New Product</a>
           {% endif %}
-          <a href="{{ url_for('billing_portal') }}" class="btn">Billing</a>
           <a href="{{ url_for('my_subscriptions') }}" class="btn">Subscriptions</a>
           <a href="{{ url_for('logout') }}" class="btn">Logout</a>
         {% else %}

--- a/templates/subscriptions.html
+++ b/templates/subscriptions.html
@@ -3,7 +3,6 @@
 {% block content %}
   <section>
     <h1>My Subscriptions</h1>
-    <p><a class="btn" href="{{ url_for('billing_portal') }}">Manage Billing</a></p>
 
     {% if not subs %}
       <p class="muted">You have no subscriptions yet.</p>


### PR DESCRIPTION
## Summary
- Automatically send buyers to Stripe billing portal when visiting subscriptions page
- Remove separate Billing link and simplify subscriptions fallback page
- Ensure Stripe billing portal returns users to home page and handle missing customers gracefully

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c183934eac832397aa87671c4897d6