### PR TITLE
Guard Stripe routes behind key checks

### DIFF
--- a/templates/product.html
+++ b/templates/product.html
@@ -7,7 +7,7 @@
     <p><strong>Price:</strong> {{ product.price_cents | usd }} / month</p>
 
     {% if current_user.is_authenticated %}
-      {% if product.stripe_price_id %}
+      {% if stripe_enabled and product.stripe_price_id %}
         <form method="post" action="{{ url_for('checkout', slug=product.slug) }}" style="margin-top: 12px;">
           <button type="submit" class="btn primary">Subscribe with Stripe</button>
         </form>


### PR DESCRIPTION
## Summary
- Enable Stripe integration only when `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` are set
- Log a warning and omit Stripe routes if keys are missing
- Update templates and routes to respect disabled Stripe integration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2e65d9de08323b3226f39c4ccf177